### PR TITLE
Generalize visualization code to multiple Mu nodes

### DIFF
--- a/src/Data/ECTA/Internal/ECTA/Type.hs
+++ b/src/Data/ECTA/Internal/ECTA/Type.hs
@@ -156,8 +156,10 @@ instance Hashable Node where
 ----------------------
 
 nodeIdentity :: Node -> Id
-nodeIdentity (InternedMu   mu)  = internedMuId mu
-nodeIdentity (InternedNode i _) = i
+nodeIdentity (InternedMu   mu)   = internedMuId mu
+nodeIdentity (InternedNode i _)  = i
+nodeIdentity (Rec (RecNodeId i)) = i
+nodeIdentity n                   = error $ "nodeIdentity: unexpected node " <> show n
 
 setChildren :: Edge -> [Node] -> Edge
 setChildren e ns = mkEdge (edgeSymbol e) ns (edgeEcs e)


### PR DESCRIPTION
I think it was currently actually broken; even with a single Mu node it was producing incorrect output. The new code does a single pass over the `Node` (using `crush`) collecting information, and then separately construct the `fgl` representation from it.

Importantly, the assumption of a single `Mu` node is no longer present. It has been replaced by a new assumption: `Mu` nodes _must_ have a normal `Node` as child. Transitions to `Mu` nodes are then rendered as edges to that normal `Node` child.