### PR TITLE
Use a general genVar function and isVar to allow all variables names

### DIFF
--- a/ecta.cabal
+++ b/ecta.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           ecta
-version:        1.0.0.3
+version:        1.0.0.4
 description:    Please see the README on GitHub at <https://github.com/jkoppel/ecta#readme>
 homepage:       https://github.com/jkoppel/ecta#readme
 bug-reports:    https://github.com/jkoppel/ecta/issues

--- a/src/Application/TermSearch/Dataset.hs
+++ b/src/Application/TermSearch/Dataset.hs
@@ -11,15 +11,7 @@ import           Application.TermSearch.Utils
 
 
 typeToFta :: TypeSkeleton -> Node
-typeToFta (TVar "a"  ) = var1
-typeToFta (TVar "b"  ) = var2
-typeToFta (TVar "c"  ) = var3
-typeToFta (TVar "d"  ) = var4
-typeToFta (TVar "acc") = varAcc
-typeToFta (TVar v) =
-  error
-    $ "Current implementation only supports function signatures with type variables a, b, c, d, and acc, but got "
-    ++ show v
+typeToFta (TVar v) = genVar v
 typeToFta (TFun  t1    t2      ) = arrowType (typeToFta t1) (typeToFta t2)
 typeToFta (TCons "Fun" [t1, t2]) = arrowType (typeToFta t1) (typeToFta t2)
 typeToFta (TCons s     ts      ) = mkDatatype s (map typeToFta ts)

--- a/src/Application/TermSearch/TermSearch.hs
+++ b/src/Application/TermSearch/TermSearch.hs
@@ -53,12 +53,15 @@ allConstructors =
 
 generalize :: Node -> Node
 generalize n@(Node [_]) = Node
-  [mkEdge s ns' (mkEqConstraints $ map pathsForVar vars)]
+  [mkEdge s ns' (mkEqConstraints $ map pathsForVar $ nodeVars n)]
  where
-  vars                = [var1, var2, var3, var4, varAcc]
-  nWithVarsRemoved    = mapNodes (\x -> if x `elem` vars then tau else x) n
+  nWithVarsRemoved    = mapNodes (\x -> if isVar x then tau else x) n
   (Node [Edge s ns']) = nWithVarsRemoved
 
+  -- Support all variable names.
+  nodeVars :: Node -> [Node]
+  nodeVars root =  crush (onNormalNodes $ \(Node es) ->
+                     filter isVar (map (\e -> Node [e]) es)) root
   pathsForVar :: Node -> [Path]
   pathsForVar v = pathsMatching (== v) n
 generalize n = error $ "cannot generalize: " ++ show n

--- a/src/Application/TermSearch/Utils.hs
+++ b/src/Application/TermSearch/Utils.hs
@@ -12,7 +12,6 @@ import           Data.ECTA.Paths
 import           Data.ECTA.Term
 
 import           Application.TermSearch.Type
-import Debug.Trace
 
 --------------------------------------------------------------------------------
 ------------------------------- Type Constructors ------------------------------

--- a/src/Application/TermSearch/Utils.hs
+++ b/src/Application/TermSearch/Utils.hs
@@ -12,6 +12,7 @@ import           Data.ECTA.Paths
 import           Data.ECTA.Term
 
 import           Application.TermSearch.Type
+import Debug.Trace
 
 --------------------------------------------------------------------------------
 ------------------------------- Type Constructors ------------------------------
@@ -63,6 +64,25 @@ var2 = Node [Edge "var2" []]
 var3 = Node [Edge "var3" []]
 var4 = Node [Edge "var4" []]
 varAcc = Node [Edge "acc" []]
+
+varPrefix :: Text
+varPrefix = "__gen_var_"
+
+-- Maintain compatibility by special-casing the common ones, otherwise
+-- using the prefix
+genVar :: Text -> Node
+genVar "a" = var1
+genVar "b" = var2
+genVar "c" = var3
+genVar "d" = var4
+genVar "acc" = varAcc
+genVar s = Node [Edge (Symbol $ varPrefix <>s) []]
+
+isVar :: Node -> Bool
+isVar x | x `elem` vars = True
+    where vars = [var1, var2, var3, var4, varAcc]
+isVar (Node [Edge (Symbol t) []]) = varPrefix `Text.isPrefixOf` t
+isVar _ = False
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
A small patch to generalize some old code, which arbitrarily restricted us to a few specific variable names.